### PR TITLE
Remove content-visibility optimization from Layout styles

### DIFF
--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -217,17 +217,6 @@ const structuredData = {
     opacity: 0.3;
   }
 
-  /* Below-the-fold セクションのレンダリング最適化 */
-  #about,
-  #doctor,
-  #hours,
-  #access,
-  #recruit,
-  #reservation {
-    content-visibility: auto;
-    contain-intrinsic-size: auto 600px;
-  }
-
   @media (max-width: 768px) {
     html {
       font-size: 18px;


### PR DESCRIPTION
## Summary
Removed CSS `content-visibility: auto` optimization rules that were applied to below-the-fold sections in the main layout.

## Changes
- Removed the `content-visibility: auto` and `contain-intrinsic-size` CSS properties from six section elements (`#about`, `#doctor`, `#hours`, `#access`, `#recruit`, `#reservation`)
- These optimizations were intended to improve rendering performance for off-screen content but are being removed in this update

## Details
The removed CSS rule was targeting below-the-fold sections with the `content-visibility: auto` property, which allows the browser to skip rendering and layout work for off-screen content. This optimization is no longer being applied to these sections.

https://claude.ai/code/session_01H4VwYHPPsoqsVygmtNrBFK