### PR TITLE
Add privacy policy page and link in footer

### DIFF
--- a/frontend/src/components/Footer.astro
+++ b/frontend/src/components/Footer.astro
@@ -49,6 +49,8 @@ const currentYear = new Date().getFullYear();
 
     <div class="footer-bottom">
       <p class="footer-legal">
+        <a href="/privacy">個人情報の取扱いについて</a>
+        <span class="footer-legal-sep" aria-hidden="true">|</span>
         <a href="/tokushoho">特定商取引法に基づく表記</a>
       </p>
       <p class="copyright">
@@ -182,6 +184,13 @@ const currentYear = new Date().getFullYear();
 
   .footer-legal a:hover {
     color: var(--color-turquoise);
+  }
+
+  .footer-legal-sep {
+    display: inline-block;
+    margin: 0 10px;
+    color: #ccc;
+    font-size: 0.8rem;
   }
 
   .copyright {

--- a/frontend/src/pages/privacy.astro
+++ b/frontend/src/pages/privacy.astro
@@ -1,0 +1,259 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+---
+
+<Layout title="個人情報の取扱いについて | 勾当台夕方内科クリニック" description="勾当台夕方内科クリニックにおける個人情報の取扱いに関する規定です。">
+  <Header />
+  <main class="legal-page">
+    <div class="container">
+      <h1 class="legal-title">個人情報の取扱いについて</h1>
+
+      <p class="legal-lead">
+        勾当台夕方内科クリニック（以下「当院」といいます）は、患者さまの個人情報の重要性を認識し、「個人情報の保護に関する法律」および関係法令・ガイドライン（「医療・介護関係事業者における個人情報の適切な取扱いのためのガイダンス」等）を遵守し、個人情報を適切に取り扱うことをお約束いたします。
+      </p>
+
+      <div class="legal-table">
+        <dl>
+          <div class="legal-row">
+            <dt>事業者名</dt>
+            <dd>勾当台夕方内科クリニック</dd>
+          </div>
+          <div class="legal-row">
+            <dt>個人情報保護管理者</dt>
+            <dd>院長 田村 慧人</dd>
+          </div>
+          <div class="legal-row">
+            <dt>個人情報の利用目的</dt>
+            <dd>
+              当院では、取得した患者さまの個人情報を以下の目的で利用いたします。これら以外の目的で利用する場合は、あらかじめご本人の同意を得るものとします。
+              <p class="policy-section">【院内での利用】</p>
+              <ul class="policy-list">
+                <li>患者さまに提供する医療サービス</li>
+                <li>医療保険事務</li>
+                <li>当院の管理運営業務のうち、会計・経理、医療事故等の報告、当該患者さまの医療サービスの向上</li>
+                <li>院内での医療実習への協力、症例検討</li>
+                <li>医療の質の向上を目的とした院内での症例研究</li>
+              </ul>
+              <p class="policy-section">【院外への情報提供】</p>
+              <ul class="policy-list">
+                <li>他の病院、診療所、薬局、訪問看護ステーション、介護サービス事業者等との連携</li>
+                <li>他の医療機関等からの照会への回答</li>
+                <li>患者さまの診療等のため、外部の医師等の意見・助言を求める場合</li>
+                <li>検体検査業務等の業務委託</li>
+                <li>ご家族等への病状説明</li>
+                <li>保険事務の委託</li>
+                <li>審査支払機関または保険者への診療報酬の請求</li>
+                <li>審査支払機関または保険者からの照会への回答</li>
+                <li>事業者等から委託を受けた健康診断等の結果通知</li>
+                <li>医師賠償責任保険等に係る、医療に関する専門団体、保険会社等への相談または届出等</li>
+              </ul>
+              <p class="policy-section">【その他の利用】</p>
+              <ul class="policy-list">
+                <li>当院の管理運営業務のうち、医療・介護サービスや業務の維持・改善のための基礎資料</li>
+                <li>外部監査機関への情報提供</li>
+              </ul>
+            </dd>
+          </div>
+          <div class="legal-row">
+            <dt>個人情報の取得</dt>
+            <dd>当院は、個人情報を取得するにあたり、利用目的を明示のうえ、適法かつ公正な手段により取得いたします。</dd>
+          </div>
+          <div class="legal-row">
+            <dt>第三者への提供</dt>
+            <dd>
+              当院は、法令に定める場合を除き、あらかじめご本人の同意を得ることなく個人情報を第三者に提供いたしません。ただし、以下の場合はこの限りではありません。
+              <ul class="policy-list">
+                <li>法令に基づく場合</li>
+                <li>人の生命、身体または財産の保護のために必要がある場合であって、ご本人の同意を得ることが困難であるとき</li>
+                <li>公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合であって、ご本人の同意を得ることが困難であるとき</li>
+                <li>国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合</li>
+              </ul>
+            </dd>
+          </div>
+          <div class="legal-row">
+            <dt>安全管理措置</dt>
+            <dd>
+              当院は、取り扱う個人情報の漏えい、滅失またはき損の防止その他の個人情報の安全管理のため、組織的・人的・物理的・技術的な安全管理措置を講じます。
+              <ul class="policy-list">
+                <li>個人情報保護に関する規程の整備および従業者への教育・研修の実施</li>
+                <li>個人情報を取り扱う区域の管理および機器・媒体等の盗難防止対策</li>
+                <li>個人情報を取り扱う情報システムへのアクセス制御、認証、外部からの不正アクセス防止措置</li>
+                <li>業務を委託する場合は、委託先に対する必要かつ適切な監督</li>
+              </ul>
+            </dd>
+          </div>
+          <div class="legal-row">
+            <dt>開示・訂正・利用停止等の請求</dt>
+            <dd>
+              ご本人またはその代理人から、保有個人データの開示、訂正、追加、削除、利用停止、第三者提供の停止等のご請求があった場合、法令に基づき適切に対応いたします。ご請求の際は、本人確認書類のご提示をお願いすることがあります。また、診療録の開示等については、所定の手数料をいただく場合があります。
+            </dd>
+          </div>
+          <div class="legal-row">
+            <dt>苦情・お問い合わせ窓口</dt>
+            <dd>
+              個人情報の取扱いに関する苦情・ご相談・お問い合わせは、下記窓口までご連絡ください。
+              <p class="policy-section">勾当台夕方内科クリニック 個人情報保護窓口</p>
+              <p>
+                電話：<a href="tel:022-393-8689">022-393-8689</a><br />
+                受付時間：水〜日 17:00〜21:00（月・火・祝休み）<br />
+                メール：<a href="mailto:info@koutoudai-yugata-naika.clinic">info@koutoudai-yugata-naika.clinic</a>
+              </p>
+            </dd>
+          </div>
+          <div class="legal-row">
+            <dt>規定の改定</dt>
+            <dd>当院は、法令の改正や業務内容の変更等に伴い、本規定を適宜見直し、改善に努めます。改定後の内容は、当院ウェブサイトに掲載した時点から効力を生じるものとします。</dd>
+          </div>
+          <div class="legal-row">
+            <dt>制定日</dt>
+            <dd>2025年12月1日</dd>
+          </div>
+        </dl>
+      </div>
+
+      <a href="/" class="back-link">トップページに戻る</a>
+    </div>
+  </main>
+  <Footer />
+</Layout>
+
+<style>
+  .legal-page {
+    padding: 120px 0 80px;
+    min-height: 100vh;
+  }
+
+  .legal-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-navy);
+    text-align: center;
+    margin-bottom: 48px;
+    letter-spacing: 0.04em;
+  }
+
+  .legal-title::after {
+    content: "";
+    display: block;
+    width: 40px;
+    height: 1px;
+    background: var(--color-navy);
+    margin: 16px auto 0;
+    opacity: 0.3;
+  }
+
+  .legal-lead {
+    max-width: 800px;
+    margin: 0 auto 40px;
+    font-size: 0.9rem;
+    line-height: 1.9;
+    color: var(--color-text-secondary);
+  }
+
+  .legal-table {
+    max-width: 800px;
+    margin: 0 auto 48px;
+  }
+
+  .legal-table dl {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .legal-row {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .legal-row dt {
+    padding: 20px 24px;
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--color-navy);
+    background: var(--color-bg-blue);
+  }
+
+  .legal-row dd {
+    padding: 20px 24px;
+    font-size: 0.9rem;
+    line-height: 1.8;
+    color: var(--color-text-secondary);
+  }
+
+  .legal-row dd a {
+    color: var(--color-orange);
+    transition: opacity 0.2s;
+  }
+
+  .legal-row dd a:hover {
+    opacity: 0.7;
+  }
+
+  .policy-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin: 4px 0 12px;
+  }
+
+  .policy-list li {
+    padding-left: 1em;
+    text-indent: -1em;
+  }
+
+  .policy-list li::before {
+    content: "・";
+  }
+
+  .policy-section {
+    font-weight: 600;
+    color: var(--color-text);
+    margin-top: 12px;
+  }
+
+  .policy-section:first-child {
+    margin-top: 0;
+  }
+
+  .policy-section + p {
+    margin-bottom: 12px;
+  }
+
+  .back-link {
+    display: block;
+    text-align: center;
+    color: var(--color-orange);
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: opacity 0.2s;
+  }
+
+  .back-link:hover {
+    opacity: 0.7;
+  }
+
+  @media (max-width: 768px) {
+    .legal-page {
+      padding: 100px 0 60px;
+    }
+
+    .legal-title {
+      font-size: 1.3rem;
+      margin-bottom: 36px;
+    }
+
+    .legal-row {
+      grid-template-columns: 1fr;
+    }
+
+    .legal-row dt {
+      padding: 14px 16px 8px;
+    }
+
+    .legal-row dd {
+      padding: 8px 16px 14px;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
This PR adds a new privacy policy page to the website and updates the footer to include a link to it.

## Key Changes
- **New Privacy Policy Page** (`frontend/src/pages/privacy.astro`)
  - Created a comprehensive privacy policy page in Japanese for 勾当台夕方内科クリニック
  - Covers personal information handling, usage purposes, data security measures, and complaint procedures
  - Includes detailed sections on in-hospital usage, external information sharing, and other uses
  - Styled with consistent legal page layout matching the existing design system
  - Responsive design with mobile-friendly layout

- **Footer Updates** (`frontend/src/components/Footer.astro`)
  - Added link to the new privacy policy page
  - Added visual separator (pipe character) between privacy policy and existing "特定商取引法に基づく表記" link
  - Styled the separator with appropriate spacing and color

## Implementation Details
- The privacy policy page uses the existing `Layout`, `Header`, and `Footer` components for consistency
- Styling uses CSS Grid for the definition list layout with a two-column design on desktop (200px labels, flexible content)
- Mobile responsive: switches to single-column layout on screens ≤768px
- Policy content is organized with subsections (院内での利用, 院外への情報提供, その他の利用) using styled list items with bullet points
- Contact information includes phone number (tel: link) and email (mailto: link) for accessibility
- Effective date set to 2025年12月1日

https://claude.ai/code/session_01LHhvpc1nbkc6UGRqxCteAs