### PR TITLE
個人情報取扱規定の制定日修正と問い合わせ窓口の一本化

### DIFF
--- a/frontend/src/pages/privacy.astro
+++ b/frontend/src/pages/privacy.astro
@@ -108,7 +108,7 @@ import Footer from "../components/Footer.astro";
           </div>
           <div class="legal-row">
             <dt>制定日</dt>
-            <dd>2025年12月1日</dd>
+            <dd>2026年4月8日</dd>
           </div>
         </dl>
       </div>

--- a/frontend/src/pages/privacy.astro
+++ b/frontend/src/pages/privacy.astro
@@ -93,12 +93,10 @@ import Footer from "../components/Footer.astro";
           <div class="legal-row">
             <dt>苦情・お問い合わせ窓口</dt>
             <dd>
-              個人情報の取扱いに関する苦情・ご相談・お問い合わせは、下記窓口までご連絡ください。
-              <p class="policy-section">勾当台夕方内科クリニック 個人情報保護窓口</p>
+              個人情報の取扱いに関する苦情・ご相談・お問い合わせは、お電話にてご連絡ください。
               <p>
                 電話：<a href="tel:022-393-8689">022-393-8689</a><br />
-                受付時間：水〜日 17:00〜21:00（月・火・祝休み）<br />
-                メール：<a href="mailto:info@koutoudai-yugata-naika.clinic">info@koutoudai-yugata-naika.clinic</a>
+                受付時間：水〜日 17:00〜21:00（月・火・祝休み）
               </p>
             </dd>
           </div>


### PR DESCRIPTION
## 概要

マージ済みの個人情報の取扱い規定ページ (#19) に対する追加修正です。

- 制定日を `2026年4月8日` に変更
- 「個人情報保護窓口」の見出しを削除
- メールアドレス (`info@koutoudai-yugata-naika.clinic`) を削除し、連絡手段をお電話に一本化

## 補足

「診療録の開示等については、所定の手数料をいただく場合があります。」の記載は、個人情報保護法第38条および厚労省「医療・介護関係事業者における個人情報の適切な取扱いのためのガイダンス」で明示的に認められており、医療法・医師法にも抵触しないため据え置いています。

## 動作確認

- [ ] `/privacy` にアクセスし、制定日が `2026年4月8日` と表示される
- [ ] 問い合わせ窓口にメールアドレスが表示されない
- [ ] 電話番号のリンクから発信できる

https://claude.ai/code/session_01LHhvpc1nbkc6UGRqxCteAs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHhvpc1nbkc6UGRqxCteAs)_